### PR TITLE
fix: check if thread is joinable to avoid crash

### DIFF
--- a/controller/src/api/command.cpp
+++ b/controller/src/api/command.cpp
@@ -29,21 +29,30 @@ int command(armwar_StatedCommand command, Motors& motors)
     if (command.start)
     {
         stop = false;
-        thread = std::thread([command, &motors, fun, &stop]() mutable {
-            while (!stop)
-            {
-                // mutex.lock();
-                fun(motors, 1);
-                // mutex.unlock();
+        if (thread.joinable()){
+            Serial.println("Thread is already started");
+        } else {
+            thread = std::thread([command, &motors, fun, &stop]() mutable {
+                while (!stop)
+                {
+                    // mutex.lock();
+                    fun(motors, 1);
+                    // mutex.unlock();
 
-                delay(SERVO_SPEED);
-            }
-        });
+                    delay(SERVO_SPEED);
+                }
+            });
+        }
     }
     else
     {
         stop = true;
-        thread.join();
+        if (thread.joinable()){
+            thread.join();
+        }
+        else{
+            Serial.println("Thread is not joinable");
+        }
     }
 
     return 0;

--- a/controller/src/server/server.cpp
+++ b/controller/src/server/server.cpp
@@ -280,6 +280,7 @@ void handleCommand(HTTPRequest* req, HTTPResponse* res)
             {
                 errorMessage = "The command sequence is too long.";
                 send_response(res, false, &errorMessage);
+                free(buffer);
                 return;
             }
 
@@ -293,6 +294,7 @@ void handleCommand(HTTPRequest* req, HTTPResponse* res)
     {
         errorMessage = "Failed to decode the command.";
         send_response(res, false, &errorMessage);
+        free(buffer);
         return;
     }
 


### PR DESCRIPTION
Prevent server crash from already stopped thread.

This can be encountered when stated command are received in the wrong order. 
(The source of this problem has not been fixed)